### PR TITLE
Fix flexible 'img' height

### DIFF
--- a/remedy.css
+++ b/remedy.css
@@ -73,6 +73,7 @@ img {
   vertical-align: bottom;  /* Fix problem with images having a tiny gap for a decender under them. */
   display: block; /* Switch display mode to block, since that's what we usually want for images. */
   max-width: 100%; /* Make images flexible by default. */
+  height: auto; /* ensure images maintain their aspect ratio when max-width comes into play. */
 }
 
 


### PR DESCRIPTION
Add `height: auto;` to img so that the aspect ratio is respected when the image is resized due to `max-width:100%;`