### PR TITLE
Add consistent line-height to common block-level typographic elements

### DIFF
--- a/remedy.css
+++ b/remedy.css
@@ -45,7 +45,7 @@ h2, h3, h4, h5, h6{
 }
 
 /* Improve readability */
-p {
+p, ul, ol, dl, address {
   line-height: 1.5;
 }
 


### PR DESCRIPTION
Not included are `blockquote`s, `figcaption`s, and form elements, which are being discussed in #9.