### PR TITLE
Add link to CSS Base/Reset/Normalize projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For years, base or reset stylesheets have helped web developers get started fast
 
 Early resets eliminated all visual styling, putting the burden of defining styles for every element on the webmaster. This made sense when there weren't as many elements or  properties, and when each browser did something very different than the others. By zeroing everything out, you start from a blank page. There were many reset stylesheets that took this approach. Eric Meyer's became the most popular. 
 
-More recently, Normalize and similar projects took a different approach. Rather than removing all styling, they set out to create sensible defaults and eliminate browser bugs. Use one of these and you get a consistent base across all browsers.
+More recently, Normalize and [similar projects](https://github.com/troxler/awesome-css-frameworks#base--reset--normalize) took a different approach. Rather than removing all styling, they set out to create sensible defaults and eliminate browser bugs. Use one of these and you get a consistent base across all browsers.
 
 CSS Remedy takes a slightly different approach. These days, browsers are far more consistent in how they render CSS. But there are limitations on how far browsers can improve their User Agent Stylesheet. The defaults for the web have to be consistent with the past. Many desirable changes would break millions of existing websites. 
 


### PR DESCRIPTION
This project looks very interesting and I'm looking forward to see how it grows :)

This PR adds a link to my list of [CSS Frameworks](https://github.com/troxler/awesome-css-frameworks), more specifically the [Base / Reset / Normalize](https://github.com/troxler/awesome-css-frameworks#base--reset--normalize) section. It might be interesting for users of—or people interested in—CSS Remedy to see what other projects exist.

PS: There is already a [PR](https://github.com/troxler/awesome-css-frameworks/pull/26) to add CSS Remedy to said list which I will gladly merge as soon as CSS Remedy is a little more mature/stable.