### PR TITLE
Exclude irrelevant files from npm releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cssremedy",
   "version": "0.1.0-beta.1",
   "description": "Start your project with a remedy for the technical debt of CSS",
-  "repository": "git@github.com:mozdevs/cssremedy.git",
+  "repository": "mozdevs/cssremedy",
   "author": "Mozilla Developer Relations",
   "license": "MPL-2.0",
   "homepage": "https://github.com/mozdevs/cssremedy/",
@@ -11,5 +11,8 @@
     "css",
     "reset",
     "default"
+  ],
+  "files": [
+      "css/*.css"
   ]
 }


### PR DESCRIPTION
Before we publish a first release, it probably makes sense to exclude extraneous files, like the whole `process/` directory, from the npm artifacts.

With this change, we'll publish the following to npm:

```
package/
├── CHANGELOG.md
├── LICENSE
├── README.md
├── css/
│  ├── quotes.css
│  ├── remedy.css
│  └── reminders.css
└── package.json
```