### PR TITLE
Update `prefers-reduced-motion`

### DIFF
--- a/css/reminders.css
+++ b/css/reminders.css
@@ -38,11 +38,12 @@ nav li:before {
 */
 @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {
-    animation-delay: -1s !important;
-    animation-duration: 1s !important;
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
     animation-iteration-count: 1 !important;
     background-attachment: initial !important;
     scroll-behavior: auto !important;
+    transition-delay: 0s !important;
     transition-duration: 0s !important;
   }
 }


### PR DESCRIPTION
Add `transition-delay: 0s` and change `animation-delay` and `-duration` to mitigate issues with a Safari bug, as described in https://github.com/mozdevs/cssremedy/issues/11#issuecomment-557808192 and https://github.com/mozdevs/cssremedy/issues/11#issuecomment-557944270.

/cc @mirisuzanne 